### PR TITLE
make compatible with 0.9

### DIFF
--- a/app/nodebb.js
+++ b/app/nodebb.js
@@ -7,7 +7,7 @@
         emitter      : NodeBB.require('./src/emitter'),
         meta         : NodeBB.require('./src/meta'),
         pluginSockets: NodeBB.require('./src/socket.io/plugins'),
-        postTools    : NodeBB.require('./src/postTools'),
+        postTools    : NodeBB.require('./src/post/tools'),
         settings     : NodeBB.require('./src/settings'),
         socketIndex  : NodeBB.require('./src/socket.io/index'),
         topics       : NodeBB.require('./src/topics'),


### PR DESCRIPTION
change postTools    : NodeBB.require('./src/postTools'), to postTools    : NodeBB.require('./src/posts/tools'),